### PR TITLE
Add OpenRouter scraping script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Health Claims
-Health Claims validation exercise 
+Health Claims validation exercise
+
+## OpenRouter scraper
+This repository includes a simple scraper that collects model information from [OpenRouter](https://openrouter.ai) and saves it as `openrouter_models.csv`.
+
+Run it with:
+
+```bash
+python scripts/openrouter_scraper.py
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+beautifulsoup4
+pandas

--- a/scripts/openrouter_scraper.py
+++ b/scripts/openrouter_scraper.py
@@ -1,0 +1,34 @@
+import requests
+from bs4 import BeautifulSoup
+import pandas as pd
+
+URL = "https://openrouter.ai/models"
+
+
+def get_models():
+    resp = requests.get(URL, timeout=10)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    models = []
+    for card in soup.select("div.model-card"):
+        name_elem = card.select_one("h3")
+        price_elem = card.select_one(".price")
+        link_elem = card.select_one("a")
+        name = name_elem.text.strip() if name_elem else ""
+        price = price_elem.text.strip() if price_elem else ""
+        link = link_elem["href"] if link_elem else ""
+        models.append({"name": name, "price": price, "link": link})
+
+    return models
+
+
+def main():
+    models = get_models()
+    df = pd.DataFrame(models)
+    df.to_csv("openrouter_models.csv", index=False)
+    print("Saved", len(df), "models to openrouter_models.csv")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add scraper to fetch model list from OpenRouter
- document how to run the scraper
- list required dependencies in requirements.txt

## Testing
- `python scripts/openrouter_scraper.py` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6878df1ea7708327b94929d27dea4cbf